### PR TITLE
Non suppression du JsTree à la fermeture des modales de subject-search-button

### DIFF
--- a/@gip-recia/evaluator/package-lock.json
+++ b/@gip-recia/evaluator/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@gip-recia/evaluator",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gip-recia/evaluator",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@gip-recia/esup-publisher-webcomponents-utils": "^0.0.2",
         "@gip-recia/subject-infos": "^0.0.10",
-        "@gip-recia/subject-search-button": "^0.0.13",
+        "@gip-recia/subject-search-button": "^0.0.14",
         "lit": "^2.2.0"
       },
       "devDependencies": {
@@ -1739,9 +1739,9 @@
       }
     },
     "node_modules/@gip-recia/subject-search-button": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@gip-recia/subject-search-button/-/subject-search-button-0.0.13.tgz",
-      "integrity": "sha512-CzufP1pCrXxV4j2l/VpjJRr4yLXgNgy7YxAEN3GFmn/ZvZeKl0Ouu+qiECTTo3nvvpWQ18qt4O6fV7Dwf8m8PA==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@gip-recia/subject-search-button/-/subject-search-button-0.0.14.tgz",
+      "integrity": "sha512-j8gohOphoW6HQTy4YcJpwFtmFSx0+zWRSQkxMC0Ut9gselFq45GcN9VvAlkw+JrxJbznciBbxd0x0nNU/lbcPg==",
       "dependencies": {
         "@gip-recia/esup-publisher-webcomponents-utils": "^0.0.2",
         "@gip-recia/js-tree": "^0.0.12",
@@ -16216,9 +16216,9 @@
       }
     },
     "@gip-recia/subject-search-button": {
-      "version": "0.0.13",
-      "resolved": "https://registry.npmjs.org/@gip-recia/subject-search-button/-/subject-search-button-0.0.13.tgz",
-      "integrity": "sha512-CzufP1pCrXxV4j2l/VpjJRr4yLXgNgy7YxAEN3GFmn/ZvZeKl0Ouu+qiECTTo3nvvpWQ18qt4O6fV7Dwf8m8PA==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/@gip-recia/subject-search-button/-/subject-search-button-0.0.14.tgz",
+      "integrity": "sha512-j8gohOphoW6HQTy4YcJpwFtmFSx0+zWRSQkxMC0Ut9gselFq45GcN9VvAlkw+JrxJbznciBbxd0x0nNU/lbcPg==",
       "requires": {
         "@gip-recia/esup-publisher-webcomponents-utils": "^0.0.2",
         "@gip-recia/js-tree": "^0.0.12",

--- a/@gip-recia/evaluator/package.json
+++ b/@gip-recia/evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gip-recia/evaluator",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Evaluator",
   "main": "src/index.js",
   "module": "src/index.js",
@@ -33,7 +33,7 @@
   "dependencies": {
     "@gip-recia/esup-publisher-webcomponents-utils": "^0.0.2",
     "@gip-recia/subject-infos": "^0.0.10",
-    "@gip-recia/subject-search-button": "^0.0.13",
+    "@gip-recia/subject-search-button": "^0.0.14",
     "lit": "^2.2.0"
   },
   "devDependencies": {

--- a/@gip-recia/subject-search-button/package-lock.json
+++ b/@gip-recia/subject-search-button/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gip-recia/subject-search-button",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gip-recia/subject-search-button",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "Apache-2.0",
       "dependencies": {
         "@gip-recia/esup-publisher-webcomponents-utils": "^0.0.2",

--- a/@gip-recia/subject-search-button/package.json
+++ b/@gip-recia/subject-search-button/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gip-recia/subject-search-button",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Subject Search Button",
   "main": "src/subject-search-button.js",
   "module": "src/subject-search-button.js",

--- a/@gip-recia/subject-search-button/src/subject-search-button.js
+++ b/@gip-recia/subject-search-button/src/subject-search-button.js
@@ -587,7 +587,7 @@ export class SubjectSearchButton extends LitElement {
     this._clearSubject()
     const tree = this.shadowRoot.querySelector('#jsTreeGroup' + this.searchId)
     if (tree) {
-      tree.remove()
+      tree.deselectAllNodes()
     }
     this._hideModal('groupListModal' + this.searchId)
   }
@@ -674,7 +674,7 @@ export class SubjectSearchButton extends LitElement {
       '#jsTreeUserFromGroup' + this.searchId
     )
     if (tree) {
-      tree.remove()
+      tree.deselectAllNodes()
     }
     this._hideModal('userFromGroupListModal' + this.searchId)
   }


### PR DESCRIPTION
Fix remise à zéro de l'état du JsTree à la fermeture des modales de subject-search-button (cf. https://github.com/GIP-RECIA/esup-publisher/issues/231)